### PR TITLE
Fix: Improve error handling for empty API responses

### DIFF
--- a/index.php
+++ b/index.php
@@ -133,10 +133,12 @@ if (isset($_POST['is_ajax'])) {
             $response['error'] = "Failed to get a response from the model. Response: " . htmlspecialchars($modelResult['body']);
         } else {
             $modelResponse = json_decode($modelResult['body']);
-            if (isset($modelResponse->candidates[0]->content->parts[0]->text)) {
+            if (!empty($modelResponse->candidates[0]->content->parts[0]->text)) {
                 $response['success'] = true;
                 $response['responseText'] = $modelResponse->candidates[0]->content->parts[0]->text;
                 $response['error'] = null;
+            } elseif (empty($modelResponse->candidates[0]->content->parts)) {
+                $response['error'] = "The model processed the request but did not return any text. This can happen due to the model's safety filters or if the video content is invalid or unsupported.";
             } else {
                 $response['error'] = "Could not find generated text in the model's response. Raw response: " . htmlspecialchars(print_r($modelResponse, true));
             }


### PR DESCRIPTION
This commit improves the backend error handling to provide a more specific and user-friendly message when the Gemini API returns a response with no generated text.

Previously, this scenario would result in a generic "Could not find generated text" error. The logic has been updated to detect this specific case and return a more informative error explaining that the model may have refused to answer due to safety settings or invalid input.