### PR TITLE
Fix: Propagate specific errors during status polling

### DIFF
--- a/index.php
+++ b/index.php
@@ -113,8 +113,10 @@ if (isset($_POST['is_ajax'])) {
                     $response['success'] = true;
                     $response['state'] = $statusResponse->state;
                     $response['error'] = null;
+                } elseif (isset($statusResponse->error->message)) {
+                    $response['error'] = 'Google API Error: ' . htmlspecialchars($statusResponse->error->message);
                 } else {
-                    $response['error'] = 'Could not retrieve file processing status.';
+                    $response['error'] = 'Could not retrieve file processing status. The response from Google was unexpected.';
                 }
             }
             break;


### PR DESCRIPTION
This commit fixes a bug where a generic error ("Could not retrieve file processing status") was shown if the Google API returned an error during the file status polling stage.

The `check_status` action in the backend has been updated to inspect the response from Google's API. If an error object is found, the specific error message is now extracted and passed along to the frontend. This provides the user with more detailed and actionable error information.