### PR TITLE
Fix: Use correct file identifier for status polling

### DIFF
--- a/index.php
+++ b/index.php
@@ -88,11 +88,11 @@ if (isset($_POST['is_ajax'])) {
                         $response['error'] = "Failed to upload video data. Response: " . htmlspecialchars($uploadResult['body']);
                     } else {
                         $uploadResponse = json_decode($uploadResult['body']);
-                        if (!isset($uploadResponse->file->uri)) {
-                            $response['error'] = 'File URI not found in the final upload response.';
+                        if (!isset($uploadResponse->file->name)) {
+                            $response['error'] = 'File Name identifier not found in the final upload response.';
                         } else {
                             $response['success'] = true;
-                            $response['fileUri'] = $uploadResponse->file->uri;
+                            $response['fileUri'] = $uploadResponse->file->name; // Use the 'name' not the 'uri'
                             $response['error'] = null;
                         }
                     }


### PR DESCRIPTION
This commit fixes a bug where the application would fail during the status polling step because it was using the wrong identifier for the uploaded file.

The `upload` action was previously returning the file's full `uri`, which resulted in a malformed URL when used in the `check_status` action.

The `upload` action has been corrected to return the file's `name` property, which is the correct identifier for constructing the status check URL. This resolves the "Could not retrieve file processing status" error.