### PR TITLE
Fix: Use full URI in generateContent API call

### DIFF
--- a/index.php
+++ b/index.php
@@ -137,7 +137,10 @@ if (isset($_POST['is_ajax'])) {
             if (empty($fileUri) || empty($prompt) || empty($mimeType)) {
                 $response['error'] = 'Missing required data for generating content.';
             } else {
-                $fileDataPayload = ['fileData' => ['mimeType' => $mimeType, 'fileUri' => $fileUri]];
+                // The `generateContent` call requires the full resource URI.
+                $fullFileUrl = "https://generativelanguage.googleapis.com/v1beta/{$fileUri}";
+                $fileDataPayload = ['fileData' => ['mimeType' => $mimeType, 'fileUri' => $fullFileUrl]];
+
                 $modelUrl = "https://generativelanguage.googleapis.com/v1beta/models/{$selectedModel}:generateContent?key={$apiKey}";
                 $modelPayload = json_encode(['contents' => [['parts' => [['text' => $prompt], $fileDataPayload]]]]);
                 $modelResult = executeCurl($modelUrl, [CURLOPT_POST => true, CURLOPT_POSTFIELDS => $modelPayload, CURLOPT_RETURNTRANSFER => true, CURLOPT_HTTPHEADER => ['Content-Type: application/json']]);


### PR DESCRIPTION
This commit fixes a bug where the application would fail on the final step with an "Unsupported file uri" error.

The `get_result` action was sending the relative file name (`files/...`) in the payload for the `generateContent` request. This endpoint requires the full, absolute resource URI.

The backend logic has been updated to construct the full URI before making the final API call. This resolves the error and should complete the end-to-end workflow.