### PR TITLE
Fix: Correctly display download button on success

### DIFF
--- a/index.php
+++ b/index.php
@@ -427,17 +427,21 @@ Describe the key actions, the setting, and the overall mood as they happen on sc
             try {
                 const response = await fetch('index.php', { method: 'POST', body: formData });
                 const result = await response.json();
-                if (result.success) {
+                if (result.success && result.responseText) {
                     lastResponseText = result.responseText;
+                    // On success, hide the submit button and show the download button
                     submitBtn.classList.add('d-none');
                     downloadBtn.classList.remove('d-none');
+                    // And reset the state of the (now hidden) submit button
+                    btnText.textContent = 'Analyze Video';
+                    btnSpinner.classList.add('d-none');
+                    submitBtn.disabled = false;
                 } else {
-                    throw new Error(result.error);
+                    throw new Error(result.error || 'Failed to get result.');
                 }
             } catch (error) {
                 showToast(`Error generating result: ${error.message}`, 'danger');
-            } finally {
-                resetUI();
+                resetUI(); // Only reset the entire UI on failure
             }
         }
 


### PR DESCRIPTION
This commit fixes a UI bug where the "Download" button would not remain visible after a successful analysis.

A `finally` block in the `getResult` JavaScript function was unconditionally resetting the UI, which reverted the button state immediately after it was correctly set.

The UI reset logic has been moved to the `catch` block, ensuring it only runs on error. The success path now correctly hides the "Analyze" button and shows the "Download" button, which now persists as intended.