### PR TITLE
fix: Handle invalid JSON response in audio conversion

### DIFF
--- a/index.php
+++ b/index.php
@@ -201,12 +201,16 @@ if (isset($_POST['is_ajax'])) {
 
                 if ($ttsResult['httpCode'] !== 200) {
                     $response['error'] = "Failed to get a response from the TTS model. Response: " . htmlspecialchars($ttsResult['body']);
-                } elseif (!empty($ttsResponse->candidates[0]->content->parts[0]->inlineData->data)) {
+                } elseif (isset($ttsResponse->candidates[0]->content->parts[0]->inlineData->data)) {
                     $response['success'] = true;
                     $response['audioData'] = $ttsResponse->candidates[0]->content->parts[0]->inlineData->data;
                     $response['error'] = null;
                 } else {
-                    $response['error'] = "Could not find audio data in the model's response. Raw response: " . htmlspecialchars(print_r($ttsResponse, true));
+                    if (is_null($ttsResponse)) {
+                        $response['error'] = "The server received an invalid (non-JSON) response from the Google API.";
+                    } else {
+                        $response['error'] = "Could not find audio data in the model's response. Raw response: " . htmlspecialchars(print_r($ttsResponse, true));
+                    }
                 }
             }
             break;
@@ -283,8 +287,7 @@ if (isset($_POST['is_ajax'])) {
                         <textarea name="prompt" id="prompt" class="form-control" rows="8" required>You are a professional narrator. Your task is to create a detailed, continuous narration script for the provided video.
 The most important rule is that the length of your spoken narration must be timed to perfectly match the video's total duration. When read aloud at a natural, unhurried pace (approximately 150 words per minute), the narration should start at the beginning of the video and end exactly when the video ends.
 Break the script into timed segments that align with key visual changes, actions, or transitions in the video. Each segment must include a precise timestamp in [HH:MM:SS] format, starting from [00:00:00] and progressing sequentially without gaps or overlaps. The final segment must end exactly at the video's total length of (HH:MM:SS). Estimate the duration of each segment based on the narration length and speaking pace to ensure the total adds up accurately.
-Describe the key actions, the setting, and the overall mood as they happen on screen in each timed segment. Do not include any introductory or concluding text. Do not write 'Here is the script,' 'Certainly,' or any other conversational phrases. Your entire response must consist ONLY of the timestamped narration script, starting directly with the first timestamp [00:00:00].</textarea>
-                   
+Describe the key actions, the setting, and the overall mood as they happen on screen in each timed segment. Do not include any introductory or concluding text. Do not write "Here is the script," "Certainly," or any other conversational phrases. Your entire response must consist ONLY of the timestamped narration script, starting directly with the first timestamp [00:00:00].</textarea>
                     </div>
 
                     <div class="d-grid gap-2">


### PR DESCRIPTION
This commit fixes a bug in the text-to-speech feature where the backend script would crash if it received a non-JSON response from the Google API.

The `convert_to_audio` action now checks if the response from the Google API can be successfully decoded as JSON before attempting to access its properties. If the response is not valid JSON, it returns a proper error message to the client instead of causing a fatal PHP error.