### PR TITLE
fix: Prevent timeout in audio conversion

### DIFF
--- a/index.php
+++ b/index.php
@@ -175,6 +175,7 @@ if (isset($_POST['is_ajax'])) {
             break;
 
         case 'convert_to_audio':
+            set_time_limit(0); // Allow script to run indefinitely for this task
             $textToConvert = $_POST['textToConvert'] ?? '';
             $voice = $_POST['voice'] ?? 'Kore'; // Default voice
             $ttsModel = 'gemini-2.5-flash-preview-tts';


### PR DESCRIPTION
This commit addresses a fatal error that occurred during text-to-speech conversion for long narration scripts.

The `convert_to_audio` action now calls `set_time_limit(0)` to prevent the PHP script from timing out while waiting for a response from the Google API. This ensures that long-running conversion requests can complete successfully.